### PR TITLE
fix: add missing Open Graph meta tags for better SEO

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -126,6 +126,9 @@ const ogImageUrl = (() => {
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content={ogType} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:site_name" content="Referendum e Iniziative Popolari" />
+    <meta property="og:locale" content="it_IT" />
     <meta property="og:image" content={ogImageUrl} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />


### PR DESCRIPTION
Added og:url, og:site_name, and og:locale meta tags to Layout.astro
to improve search engine indexing and social media sharing.

These tags help Google and other search engines better understand
the site context and prevent incorrect indexing as "GitHub Pages documentation".

- og:url: canonical URL for Open Graph protocol
- og:site_name: site name for better context
- og:locale: it_IT for proper Italian localization